### PR TITLE
Mobile clear selections

### DIFF
--- a/app.py
+++ b/app.py
@@ -282,22 +282,29 @@ def session_selector_refresh(panel_open, event_select_value, events_and_sessions
     )
 
 
-# Request session datasets
+# Clear selected data on new session load or crossfilter clear
 @dash_app.callback(
     Output("selected_session", "data"),
     Output("lap_plot", "selectedData"),
     Output("track_map", "selectedData"),
     Output("conditions_plot", "selectedData"),
     Input("load_button", "n_clicks"),
+    Input("clear_crossfilters_button", "n_clicks"),
     State("event_select", "value"),
     State("session_select", "value"),
     State("selected_session", "data"),
     State("client_info", "data")
 )
-def request_datasets(click, event_id, session_name, selected_session_state, client_info):
-    if click is None:
+def request_datasets(load_click, clear_crossfilters_click, event_id, session_name, selected_session_state, client_info):
+
+    # Crossfilters clear
+    if callback_context.triggered[0]["prop_id"].split(".")[0] == "clear_crossfilters_button":
+        return no_update, None, None, no_update
+
+    # Session load
+    if load_click is None:
         new_request = False
-    if click is not None and selected_session_state is None:
+    if load_click is not None and selected_session_state is None:
         new_request = True
     if selected_session_state is not None:
         selected_session_state = json.loads(selected_session_state)
@@ -397,6 +404,16 @@ def open_conditions_panel(click, client_info):
         return True        
     else:
         return False   
+
+
+# Set clear crossfilters button colour
+@dash_app.callback(
+    Output("clear_crossfilters_button", "disabled"),
+    Input("lap_plot", "selectedData"),
+    Input("track_map", "selectedData")
+)
+def set_clear_filters_button(lap_plot_selection, track_map_selection):
+    return lap_plot_selection is None and track_map_selection is None
 
 
 ### Callback for each dropdown filter
@@ -732,4 +749,4 @@ def conditions_plot_refresh(datasets, conditions_plot_selection, conditions_plot
         
 if __name__ == "__main__":
     # Azure host will not run this
-    dash_app.run_server(debug=False)
+    dash_app.run_server(debug=True)

--- a/layouts.py
+++ b/layouts.py
@@ -335,8 +335,8 @@ layout_desktop = [
                 children=[
                     dbc.Row(
                         [
-                            dbc.Col(dbc.Button("Filters", id="open_parameters_button", style={"margin-left": "10px"}), xs=5),
-                            dbc.Col(dbc.Button(id="open_conditions_button", children="Open timeline"), xs=2),
+                            dbc.Col(dbc.Button("Open Filters", id="open_parameters_button", style={"margin-left": "10px"}), xs=5),
+                            dbc.Col(dbc.Button(id="open_conditions_button", children="Open Timeline"), xs=2),
                             dbc.Col(html.P(short_abstract_text), style={"font-size": "0.9rem"}, xs=5)
                         ],
                         align="start",

--- a/layouts.py
+++ b/layouts.py
@@ -343,6 +343,10 @@ layout_desktop = [
                         justify="start"
                     ),
                 ]
+            ),
+            html.Div(
+                children=[dbc.Button(id="clear_crossfilters_button")],
+                hidden=True
             )
         ]
     ),
@@ -390,12 +394,18 @@ layout_mobile = [
                         children=[
                             html.Div(id="upper_heading", hidden=True),
                             dbc.Row(dbc.Col(html.H1(id="lower_heading"), xs=12)),
-                            html.Hr(),
+                            html.Br(),
                             dbc.Row(
                                 [
-                                    dbc.Col(dbc.Button(id="open_parameters_button", children="Open Filters", size="sm"), xs=4),
-                                    dbc.Col(html.P(short_abstract_text, style={"font-size": "0.75rem"}), xs=8)
+                                    dbc.Col(html.P(short_abstract_text, style={"font-size": "0.75rem"}), xs=12)
                                 ]
+                            ),
+                            dbc.Row(
+                                [
+                                    dbc.Col(dbc.Button(id="open_parameters_button", children="Open Filters", size="sm"), xs=6),
+                                    dbc.Col(dbc.Button(id="clear_crossfilters_button", children="Clear Selections", size="sm", disabled=True), xs=5),
+                                ],
+                                justify="between"
                             )
                         ]
                     ),


### PR DESCRIPTION
Added 'clear selections' button (visible in mobile layout only - in a hidden div in desktop layout) to assist with clearing filters on a touch screen. 

Plotly visuals don't respond to double taps, and instead rely on the user tapping their currently selected point a second time (which is borderline impossible on the track map), so this is a workaround for the forseeable.

Callbacks have been updated to incorporate this button.

Also relabeled desktop layout's footer buttons for consistency.