### PR TITLE
Preseason data

### DIFF
--- a/visuals.py
+++ b/visuals.py
@@ -1059,7 +1059,9 @@ def build_conditions_plot(data_dict, client_info):
 
     # Hover labels
     for metric in metrics:
-        data["text_" + metric] = data[metric].apply(lambda x: str(x) + metrics[metric]["text_suffix"])
+        data["text_" + metric] = data[metric].apply(
+            lambda x: str(x) + metrics[metric]["text_suffix"] if x is not None else "Unavailable"
+        )
 
     # Traces
     y_values = []


### PR DESCRIPTION
Allow sessions to be pulled from API when weather data is missing. 
When conditions data is read from db, synthesize the time steps that would have been sourced from the weather data. 
Handle null data in conditions plot visual.

Resolves issue #14 - Handle sessions with incomplete data to enable viewing preseason testing - for 2022's preseason testing in Bahrain (not the sessions in Barcelona, which are unsupported by the F1 API). Remains to be seen what kind of shape 2023's preseason data will be in.
